### PR TITLE
Add JWT to Docker pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN pip install --no-cache-dir \
     boto3 \
     prompt_toolkit \
     google-auth \
-	requests
+    requests \
+    pyjwt
 
 # Copy the Python script and shell script into the container
 COPY emailproxy.py /app/


### PR DESCRIPTION
Requirements of the core project added pyjwt, which is required to use certificates for O365.

Another option would be to do:
```
RUN pip install email-oauth2-proxy \
 && python -m pip install --no-cache-dir -r https://raw.githubusercontent.com/simonrob/email-oauth2-proxy/main/requirements-core.txt
```